### PR TITLE
Add an SVG preview route, and exports to PDF and PNG using Playwright

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -16,6 +16,42 @@ export default function Index() {
       <Link to="/setup-page" className="underline text-blue-500">
         Get Started
       </Link>
+      <h2>Previews</h2>
+      <DemoTable />
     </div>
+  );
+}
+
+function DemoTable() {
+  const demos = [
+    {
+      pageTitle: "Louis",
+      firstDayOfWeek: "Sunday",
+      bgImage: "https://picsum.photos/id/17/3000/2000",
+    },
+    {
+      pageTitle: "Hugo",
+      firstDayOfWeek: "Monday",
+      bgImage: "https://picsum.photos/id/18/3000/2000",
+    },
+  ];
+  const formats = ["svg", "pdf", "png"];
+  return (
+    <table className="table-auto border-collapse w-full">
+      {demos.map((demo) => (
+        <tr key={demo.pageTitle}>
+          <th className="border-slate-200 p-4 border-y">{demo.pageTitle}</th>
+          {formats.map((format) => (
+            <td key={format} className="border-slate-200 p-4 border-y">
+              <a
+                href={`/preview-plan.${format}?pageTitle=${demo.pageTitle}&firstDayOfWeek=${demo.firstDayOfWeek}&bgImage=${demo.bgImage}`}
+              >
+                {format.toUpperCase()}
+              </a>
+            </td>
+          ))}
+        </tr>
+      ))}
+    </table>
   );
 }

--- a/app/routes/preview-plan[.]pdf.tsx
+++ b/app/routes/preview-plan[.]pdf.tsx
@@ -1,0 +1,27 @@
+import { LoaderFunctionArgs } from "@remix-run/node";
+import { chromium, devices } from "playwright";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  // Get the same URL, with the query parameters, except `preview-plan.svg` instead of `preview-plan.pdf`
+  const svgUrl = new URL(request.url);
+  svgUrl.pathname = "preview-plan.svg";
+
+  const pdf = await generatePdfFromUrl(svgUrl.toString());
+  return new Response(pdf, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/pdf",
+    },
+  });
+}
+
+async function generatePdfFromUrl(url: string) {
+  const browser = await chromium.launch();
+  const context = await browser.newContext(devices["Desktop Chrome"]);
+  const page = await context.newPage();
+  await page.goto(url);
+  const pdfBuffer = await page.pdf({ width: "30cm", height: "20cm" });
+  await context.close();
+  await browser.close();
+  return pdfBuffer;
+}

--- a/app/routes/preview-plan[.]png.tsx
+++ b/app/routes/preview-plan[.]png.tsx
@@ -1,0 +1,41 @@
+import { LoaderFunctionArgs } from "@remix-run/node";
+import { chromium, devices } from "playwright";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  // Get the same URL, with the query parameters, except `preview-plan.svg` instead of `preview-plan.png`
+  const svgUrl = new URL(request.url);
+  svgUrl.pathname = "preview-plan.svg";
+
+  console.log("generate png", svgUrl);
+
+  const png = await generatePngFromUrl(svgUrl.toString());
+  return new Response(png, {
+    status: 200,
+    headers: {
+      "Content-Type": "image/png",
+    },
+  });
+}
+
+async function generatePngFromUrl(url: string) {
+  const browser = await chromium.launch();
+  const context = await browser.newContext(devices["Desktop Chrome"]);
+  const page = await context.newPage();
+  // Note, calling `page.screenshot()` seems to hang for unknown reasons.
+  // This comment on GitHub suggested using raw "Chrome Devtools Protocol" (cdp)
+  // https://github.com/microsoft/playwright/issues/15773#issuecomment-1292776820
+  const cdpSession = await context.newCDPSession(page);
+  await page.goto(url);
+  // TODO: figure out how to make the SVG export at the size we want. The inkscape export of 300mm*200mm at 300dpi is 3543 × 2362
+  page.setViewportSize({ width: 1133, height: 755 });
+  const screenshotReturnValue = await cdpSession.send(
+    "Page.captureScreenshot",
+    {
+      captureBeyondViewport: true,
+    }
+  );
+  const base64Str = screenshotReturnValue.data;
+  await context.close();
+  await browser.close();
+  return Buffer.from(base64Str, "base64");
+}

--- a/app/routes/preview-plan[.]svg.tsx
+++ b/app/routes/preview-plan[.]svg.tsx
@@ -1,0 +1,106 @@
+import { LoaderFunctionArgs } from "@remix-run/node";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const url = new URL(request.url);
+  const pageTitle = url.searchParams.get("pageTitle") || "Your title here";
+  const firstDayOfWeek = url.searchParams.get("firstDayOfWeek");
+  const bgImage =
+    url.searchParams.get("bgImage") || "https://picsum.photos/id/16/3000/2000";
+  const days =
+    firstDayOfWeek !== "monday"
+      ? [
+          "Sunday",
+          "Monday",
+          "Tuesday",
+          "Wednesday",
+          "Thursday",
+          "Friday",
+          "Saturday",
+        ]
+      : [
+          "Monday",
+          "Tuesday",
+          "Wednesday",
+          "Thursday",
+          "Friday",
+          "Saturday",
+          "Sunday",
+        ];
+  const svg = svgTemplate
+    .replace("{{pageTitle}}", pageTitle)
+    .replace("{{day1}}", days[0])
+    .replace("{{day2}}", days[1])
+    .replace("{{day3}}", days[2])
+    .replace("{{day4}}", days[3])
+    .replace("{{day5}}", days[4])
+    .replace("{{day6}}", days[5])
+    .replace("{{day7}}", days[6])
+    .replace("{{bgImage}}", bgImage);
+  return new Response(svg, {
+    status: 200,
+    headers: {
+      "Content-Type": "image/svg+xml",
+    },
+  });
+}
+
+const svgTemplate = `<?xml version="1.0" encoding="UTF-8"?>
+<svg width="300mm" height="200mm" version="1.1" viewBox="0 0 300 200" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <clipPath id="clipPath103">
+      <rect x="314.84" y="-205.93" width="300" height="200" style="fill:#bf86f3" />
+    </clipPath>
+  </defs>
+  <image transform="translate(-314.84 205.93)" x="307.6" y="-211.09" width="317.3" height="211.09" clip-path="url(#clipPath103)" preserveAspectRatio="none" xlink:href="{{bgImage}}" />
+  <g transform="translate(-316.18 200.63)">
+    <rect x="320.44" y="-157.72" width="39.329" height="149.33" ry="4.3387" style="fill-opacity:.84574;fill:#ffffff" />
+    <rect x="572.59" y="-157.72" width="39.329" height="149.33" ry="4.3387" style="fill-opacity:.84574;fill:#ffffff" />
+    <rect x="530.56" y="-157.72" width="39.329" height="149.33" ry="4.3387" style="fill-opacity:.84574;fill:#ffffff" />
+    <rect x="488.54" y="-157.72" width="39.329" height="149.33" ry="4.3387" style="fill-opacity:.84574;fill:#ffffff" />
+    <rect x="446.51" y="-157.72" width="39.329" height="149.33" ry="4.3387" style="fill-opacity:.84574;fill:#ffffff" />
+    <rect x="404.49" y="-157.72" width="39.329" height="149.33" ry="4.3387" style="fill-opacity:.84574;fill:#ffffff" />
+    <rect x="362.46" y="-157.72" width="39.329" height="149.33" ry="4.3387" style="fill-opacity:.84574;fill:#ffffff" />
+  </g>
+  <rect x="-264.94" y="226.15" width="0" height="0" rx="1" style="fill:#ffffff;stroke-dasharray:0.308271, 0.308271;stroke-width:.30827;stroke:#000000" />
+  <rect x="-223.74" y="226.15" width="0" height="0" rx="1" style="fill:#ffffff;stroke-dasharray:0.308271, 0.308271;stroke-width:.30827;stroke:#000000" />
+  <rect x="-182.53" y="226.15" width="0" height="0" rx="1" style="fill:#ffffff;stroke-dasharray:0.308271, 0.308271;stroke-width:.30827;stroke:#000000" />
+  <rect x="-141.33" y="226.15" width="0" height="0" rx="1" style="fill:#ffffff;stroke-dasharray:0.308271, 0.308271;stroke-width:.30827;stroke:#000000" />
+  <rect x="-100.13" y="226.15" width="0" height="0" rx="1" style="fill:#ffffff;stroke-dasharray:0.308271, 0.308271;stroke-width:.30827;stroke:#000000" />
+  <rect x="-58.923" y="226.15" width="0" height="0" rx="1" style="fill:#ffffff;stroke-dasharray:0.308271, 0.308271;stroke-width:.30827;stroke:#000000" />
+  <rect x="-306.14" y="226.15" width="0" height="0" rx="1" style="fill:#ffffff;stroke-dasharray:0.308271, 0.308271;stroke-width:.30827;stroke:#000000" />
+  <rect x="-263.71" y="266.84" width="0" height="0" rx="1" style="fill:#ffffff;stroke-dasharray:0.308271, 0.308271;stroke-width:.30827;stroke:#000000" />
+  <rect x="-222.5" y="266.84" width="0" height="0" rx="1" style="fill:#ffffff;stroke-dasharray:0.308271, 0.308271;stroke-width:.30827;stroke:#000000" />
+  <rect x="-181.3" y="266.84" width="0" height="0" rx="1" style="fill:#ffffff;stroke-dasharray:0.308271, 0.308271;stroke-width:.30827;stroke:#000000" />
+  <rect x="-140.1" y="266.84" width="0" height="0" rx="1" style="fill:#ffffff;stroke-dasharray:0.308271, 0.308271;stroke-width:.30827;stroke:#000000" />
+  <rect x="-98.894" y="266.84" width="0" height="0" rx="1" style="fill:#ffffff;stroke-dasharray:0.308271, 0.308271;stroke-width:.30827;stroke:#000000" />
+  <rect x="-57.691" y="266.84" width="0" height="0" rx="1" style="fill:#ffffff;stroke-dasharray:0.308271, 0.308271;stroke-width:.30827;stroke:#000000" />
+  <rect x="-304.91" y="266.84" width="0" height="0" rx="1" style="fill:#ffffff;stroke-dasharray:0.308271, 0.308271;stroke-width:.30827;stroke:#000000" />
+  <rect x="-341.19" y="207.61" width="0" height="0" rx="1" style="fill:#1a1a1a;stroke-dasharray:0.349999, 0.349999;stroke-width:.35;stroke:#000000" />
+  <text x="149.44812" y="30.656967" style="fill:#ffffff;font-size:25.4px;stroke-width:.8" xml:space="preserve">
+    <tspan x="149.44812" y="30.656967" style="fill:#ffffff;font-family:Futura;font-size:25.4px;font-weight:500;stroke-width:.8;text-align:center;text-anchor:middle">{{pageTitle}}</tspan>
+  </text>
+  <text x="25.016388" y="60.132065" style="fill:#ffffff;font-size:6.35px;stroke-width:.136;stroke:#000000;text-align:center;text-anchor:middle" xml:space="preserve">
+    <tspan x="25.016388" y="60.132065" style="fill:#000400;font-family:'PT Serif';font-size:6.35px;stroke-width:.136;stroke:none;text-align:center;text-anchor:middle">{{day1}}</tspan>
+  </text>
+  <text x="67.144196" y="60.132065" style="fill:#ffffff;font-size:6.35px;stroke-width:.136;stroke:#000000;text-align:center;text-anchor:middle" xml:space="preserve">
+    <tspan x="67.144196" y="60.132065" style="fill:#000400;font-family:'PT Serif';font-size:6.35px;stroke-width:.136;stroke:none;text-align:center;text-anchor:middle">{{day2}}</tspan>
+  </text>
+  <text x="109.20496" y="60.132065" style="fill:#ffffff;font-size:6.35px;stroke-width:.136;stroke:#000000;text-align:center;text-anchor:middle" xml:space="preserve">
+    <tspan x="109.20496" y="60.132065" style="fill:#000400;font-family:'PT Serif';font-size:6.35px;stroke-width:.136;stroke:none;text-align:center;text-anchor:middle">{{day3}}</tspan>
+  </text>
+  <text x="151.29745" y="60.132065" style="fill:#ffffff;font-size:6.35px;stroke-width:.136;stroke:#000000;text-align:center;text-anchor:middle" xml:space="preserve">
+    <tspan x="151.29745" y="60.132065" style="fill:#000400;font-family:'PT Serif';font-size:6.35px;stroke-width:.136;stroke:none;text-align:center;text-anchor:middle">{{day4}}</tspan>
+  </text>
+  <text x="193.25592" y="60.132065" style="fill:#ffffff;font-size:6.35px;stroke-width:.136;stroke:#000000;text-align:center;text-anchor:middle" xml:space="preserve">
+    <tspan x="193.25592" y="60.132065" style="fill:#000400;font-family:'PT Serif';font-size:6.35px;stroke-width:.136;stroke:none;text-align:center;text-anchor:middle">{{day5}}</tspan>
+  </text>
+  <text x="235.24612" y="59.405594" style="fill:#ffffff;font-size:6.35px;stroke-width:.136;stroke:#000000;text-align:center;text-anchor:middle" xml:space="preserve">
+    <tspan x="235.24612" y="59.405594" style="fill:#000400;font-family:'PT Serif';font-size:6.35px;stroke-width:.136;stroke:none;text-align:center;text-anchor:middle">{{day6}}</tspan>
+  </text>
+  <text x="277.90768" y="59.405594" style="fill:#ffffff;font-size:7.0556px;stroke-width:.136;stroke:#000000;text-align:center;text-anchor:middle" xml:space="preserve">
+    <tspan x="277.90768" y="59.405594" style="fill:#000400;font-family:'PT Serif';font-size:7.0556px;stroke-width:.136;stroke:none;text-align:center;text-anchor:middle">{{day7}}</tspan>
+  </text>
+  <text x="114.35669" y="166.50917" style="fill-opacity:.84574;fill:#ffffff;font-family:Futura;font-size:6.35px;font-weight:500;stroke-dasharray:0.370999, 1.113;stroke-width:.371;text-align:center;text-anchor:middle" xml:space="preserve">
+    <tspan x="114.35669" y="166.50917" style="stroke-width:.371">t</tspan>
+  </text>
+</svg>`;

--- a/package.json
+++ b/package.json
@@ -13,10 +13,12 @@
     "typecheck": "tsc"
   },
   "dependencies": {
+    "@playwright/browser-chromium": "^1.43.1",
     "@remix-run/node": "^2.8.1",
     "@remix-run/react": "^2.8.1",
     "@remix-run/serve": "^2.8.1",
     "isbot": "^4.1.0",
+    "playwright": "^1.43.1",
     "prettier": "^3.2.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@playwright/browser-chromium':
+    specifier: ^1.43.1
+    version: 1.43.1
   '@remix-run/node':
     specifier: ^2.8.1
     version: 2.8.1(typescript@5.1.6)
@@ -17,6 +20,9 @@ dependencies:
   isbot:
     specifier: ^4.1.0
     version: 4.1.0
+  playwright:
+    specifier: ^1.43.1
+    version: 1.43.1
   prettier:
     specifier: ^3.2.5
     version: 3.2.5
@@ -1039,6 +1045,14 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /@playwright/browser-chromium@1.43.1:
+    resolution: {integrity: sha512-CBuHhRIF/VGyUnPvK7/4IUbm0AAOZZI5huHlr+qNr5cFQpQ6TXBqOwSMef/xUz9HcjxWOxDPION7br1kOlyV/A==}
+    engines: {node: '>=16'}
+    requiresBuild: true
+    dependencies:
+      playwright-core: 1.43.1
+    dev: false
 
   /@remix-run/dev@2.8.1(@remix-run/serve@2.8.1)(typescript@5.1.6)(vite@5.1.0):
     resolution: {integrity: sha512-qFt4jAsAJeIOyg6ngeSnTG/9Z5N9QJfeThP/8wRHc1crqYgTiEtcI3DZ8WlAXjVSF5emgn/ZZKqzLAI02OgMfQ==}
@@ -3176,6 +3190,14 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
 
+  /fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4925,6 +4947,22 @@ packages:
       mlly: 1.6.1
       pathe: 1.1.2
     dev: true
+
+  /playwright-core@1.43.1:
+    resolution: {integrity: sha512-EI36Mto2Vrx6VF7rm708qSnesVQKbxEWvPrfA1IPY6HgczBplDx7ENtx+K2n4kJ41sLLkuGfmb0ZLSSXlDhqPg==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dev: false
+
+  /playwright@1.43.1:
+    resolution: {integrity: sha512-V7SoH0ai2kNt1Md9E3Gwas5B9m8KR2GVvwZnAI6Pg0m3sh7UvgiYhRrhsziCmqMJNouPckiOhk8T+9bSAK0VIA==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dependencies:
+      playwright-core: 1.43.1
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: false
 
   /possible-typed-array-names@1.0.0:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}


### PR DESCRIPTION
Proof of concept for rendering PDFs and PNGs from SVGs

- Adds Playwright and headless Chrome to dependencies
- Adds a `preview-plan.svg` route that loads a basic SVG, substituting in values from query parameters
- Adds a `preview-plan.pdf` that renders the SVG as a PDF using playwright
- Adds a `preview-plan.png` that renders the SVG as a PNG using playwright
- Adds links to the homepage to demo each of these

This is all working well enough on my machine. Curious to hear if it's working on windows without hassle!

The main unanswered question I have from this is how to get the DPI right - the SVG is defined as being "300mm" wide and "200mm" high. Inkscape exports this at 300dpi for a resolution of 3543 × 2362. The PNG at least is a lot lower than that, and I haven't tested the PDF yet.
