### PR TITLE
Add ability to print magnet grids

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,3 +34,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
       - run: pnpm build
+
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: pnpm vitest run

--- a/app/components/ImageUploadField.tsx
+++ b/app/components/ImageUploadField.tsx
@@ -92,8 +92,13 @@ export function ImageUploadField({
     handleUpload(e, true);
   }
 
+  function removeUpload() {
+    setImageKey(null);
+    setImageSrc(null);
+  }
+
   return (
-    <label className="border-t border-b border-gray-400 border-solid p-4 flex flex-col">
+    <div className="border-t border-b border-gray-400 border-solid p-4 flex flex-col">
       {label}:
       {imageSrc && imageKey ? (
         <div className="h-auto max-w-[300px]">
@@ -106,6 +111,12 @@ export function ImageUploadField({
             </dd>
           </dl>
           <input type="hidden" name={name} value={imageKey} />
+          <button
+            onClick={() => removeUpload()}
+            className="border-solid border-black border w-fit p-1"
+          >
+            Remove photo
+          </button>
         </div>
       ) : (
         <>
@@ -135,6 +146,6 @@ export function ImageUploadField({
           </button>
         </>
       )}
-    </label>
+    </div>
   );
 }

--- a/app/components/ImageUploadField.tsx
+++ b/app/components/ImageUploadField.tsx
@@ -29,6 +29,19 @@ export function ImageUploadField({
     }
   }, [existingUploadKey]);
 
+  // Prevent drag/drop from navigating away from the page
+  useEffect(() => {
+    function preventDefault(e: DragEvent) {
+      e.preventDefault();
+    }
+    document.addEventListener("dragover", preventDefault);
+    document.addEventListener("drop", preventDefault);
+    return () => {
+      document.removeEventListener("dragover", preventDefault);
+      document.removeEventListener("drop", preventDefault);
+    };
+  }, []);
+
   async function handleUpload(
     e: React.FormEvent | React.DragEvent,
     drop: boolean = false
@@ -69,9 +82,11 @@ export function ImageUploadField({
       }
     }
   }
+
   function handleDragOver(e: React.DragEvent) {
     e.preventDefault();
   }
+
   function handleDrop(e: React.DragEvent) {
     e.preventDefault();
     handleUpload(e, true);

--- a/app/components/MagnetGrid.tsx
+++ b/app/components/MagnetGrid.tsx
@@ -1,0 +1,20 @@
+export function MagnetGrid({
+  images,
+}: {
+  images: Array<{ presignedUrl: string | null; name: string }>;
+}) {
+  const noMoreThan9Images = images.slice(0, 9);
+  return (
+    <ul className="grid grid-cols-3 grid-rows-3 place-content-around aspect-square w-[125mm] gap-[6mm] p-[3mm] m-3 bg-white border-2">
+      {noMoreThan9Images.map((magnet, i) => (
+        <li key={i} className="bg-black relative overflow-clip">
+          <img
+            src={magnet.presignedUrl || "BROKE"}
+            alt={magnet.name}
+            className="absolute inset-0 object-cover w-full h-full"
+          />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/app/components/MagnetGrid.tsx
+++ b/app/components/MagnetGrid.tsx
@@ -1,15 +1,17 @@
-export function MagnetGrid({
-  images,
-}: {
-  images: Array<{ presignedUrl: string | null; name: string }>;
-}) {
+import { Magnet } from "~/store/page.client";
+
+export type MagnetImage = Magnet & {
+  presignedUrl: string;
+};
+
+export function MagnetGrid({ images }: { images: Array<MagnetImage> }) {
   const noMoreThan9Images = images.slice(0, 9);
   return (
     <ul className="grid grid-cols-3 grid-rows-3 place-content-around aspect-square w-[125mm] gap-[6mm] p-[3mm] m-3 bg-white border-2">
       {noMoreThan9Images.map((magnet, i) => (
         <li key={i} className="bg-black relative overflow-clip">
           <img
-            src={magnet.presignedUrl || "BROKE"}
+            src={magnet.presignedUrl}
             alt={magnet.name}
             className="absolute inset-0 object-cover w-full h-full"
           />

--- a/app/components/MagnetGrid.tsx
+++ b/app/components/MagnetGrid.tsx
@@ -3,7 +3,7 @@ import { SignedMagnet } from "~/store/Magnet";
 export function MagnetGrid({ images }: { images: Array<SignedMagnet> }) {
   const noMoreThan9Images = images.slice(0, 9);
   return (
-    <ul className="grid grid-cols-3 grid-rows-3 place-content-around aspect-square w-[125mm] gap-[6mm] p-[3mm] m-3 bg-white border-2">
+    <ul className="grid grid-cols-3 grid-rows-3 place-content-around aspect-square w-[125mm] gap-[6mm] p-[3mm] m-3 bg-white">
       {noMoreThan9Images.map((magnet, i) => (
         <li key={i} className="bg-black relative overflow-clip">
           <img

--- a/app/components/MagnetGrid.tsx
+++ b/app/components/MagnetGrid.tsx
@@ -3,7 +3,7 @@ import { SignedMagnet } from "~/store/Magnet";
 export function MagnetGrid({ images }: { images: Array<SignedMagnet> }) {
   const noMoreThan9Images = images.slice(0, 9);
   return (
-    <ul className="grid grid-cols-3 grid-rows-3 place-content-around aspect-square w-[125mm] gap-[6mm] p-[3mm] m-3 bg-white">
+    <ul className="grid grid-cols-3 grid-rows-3 place-content-around aspect-square w-[125mm] gap-[6mm] p-[3mm] bg-white">
       {noMoreThan9Images.map((magnet, i) => (
         <li key={i} className="bg-black relative overflow-clip">
           <img

--- a/app/components/MagnetGrid.tsx
+++ b/app/components/MagnetGrid.tsx
@@ -1,10 +1,6 @@
-import { Magnet } from "~/store/page.client";
+import { SignedMagnet } from "~/store/Magnet";
 
-export type MagnetImage = Magnet & {
-  presignedUrl: string;
-};
-
-export function MagnetGrid({ images }: { images: Array<MagnetImage> }) {
+export function MagnetGrid({ images }: { images: Array<SignedMagnet> }) {
   const noMoreThan9Images = images.slice(0, 9);
   return (
     <ul className="grid grid-cols-3 grid-rows-3 place-content-around aspect-square w-[125mm] gap-[6mm] p-[3mm] m-3 bg-white border-2">

--- a/app/routes/download-or-print.tsx
+++ b/app/routes/download-or-print.tsx
@@ -2,6 +2,7 @@ import { useLoaderData } from "@remix-run/react";
 import PageNav from "~/components/PageNav";
 import { page } from "~/store/page.client";
 import { getDownloadUrl } from "./get-download-url";
+import { splitEvery, repeat } from "ramda";
 
 /** The client side loader, which runs after hydrate. Data from the serverLoader (`loader()`) is also available. */
 export async function clientLoader() {
@@ -71,6 +72,7 @@ export default function DownloadOrPrint() {
           </li>
         </ul>
       </details>
+      <PrintAllGrids magnets={magnets} />
       <a href={pdfUrl}>PDF Download</a>
       <iframe
         src={pdfUrl}
@@ -84,5 +86,43 @@ export default function DownloadOrPrint() {
         nextText="- Want Another One?"
       />
     </>
+  );
+}
+
+function PrintAllGrids({
+  magnets,
+}: {
+  magnets: Array<{
+    presignedUrl: string | null;
+    name: string;
+    quantity: number;
+  }>;
+}) {
+  const allImages = magnets.flatMap((magnet) =>
+    repeat(magnet, magnet.quantity)
+  );
+  const gridsOfImages = splitEvery(9)(allImages);
+  return gridsOfImages.map((images, i) => (
+    <MagnetGrid key={i} images={images} />
+  ));
+}
+
+function MagnetGrid({
+  images,
+}: {
+  images: Array<{ presignedUrl: string | null; name: string }>;
+}) {
+  return (
+    <ul className="grid grid-cols-3 grid-rows-3 place-content-around aspect-square w-[125mm] gap-[6mm] p-[3mm] m-3 bg-white border-2">
+      {images.map((magnet, i) => (
+        <li key={i} className="bg-black relative overflow-clip">
+          <img
+            src={magnet.presignedUrl || "BROKE"}
+            alt={magnet.name}
+            className="absolute inset-0 object-cover w-full h-full"
+          />
+        </li>
+      ))}
+    </ul>
   );
 }

--- a/app/routes/download-or-print.tsx
+++ b/app/routes/download-or-print.tsx
@@ -3,6 +3,7 @@ import PageNav from "~/components/PageNav";
 import { page } from "~/store/page.client";
 import { getDownloadUrl } from "./get-download-url";
 import { MagnetGrid } from "~/components/MagnetGrid";
+import { getPreviewMagnetUrl } from "./preview-magnets";
 import { setupMagnetGroups, SignedMagnet } from "~/store/Magnet";
 
 /** The client side loader, which runs after hydrate. Data from the serverLoader (`loader()`) is also available. */
@@ -83,7 +84,9 @@ export default function DownloadOrPrint() {
       </details>
       <ul>
         {setupMagnetGroups(magnets).map((imagesForGrid, i) => (
-          <li key={i}>{imagesForGrid.length}</li>
+          <li key={i}>
+            <a href={getPreviewMagnetUrl(imagesForGrid)}>Link to grid {i}</a>
+          </li>
         ))}
       </ul>
       {setupMagnetGroups(presignedMagnets).map((images, i) => (

--- a/app/routes/download-or-print.tsx
+++ b/app/routes/download-or-print.tsx
@@ -3,6 +3,7 @@ import PageNav from "~/components/PageNav";
 import { page } from "~/store/page.client";
 import { getDownloadUrl } from "./get-download-url";
 import { splitEvery, repeat } from "ramda";
+import { MagnetGrid } from "~/components/MagnetGrid";
 
 /** The client side loader, which runs after hydrate. Data from the serverLoader (`loader()`) is also available. */
 export async function clientLoader() {
@@ -105,24 +106,4 @@ function PrintAllGrids({
   return gridsOfImages.map((images, i) => (
     <MagnetGrid key={i} images={images} />
   ));
-}
-
-function MagnetGrid({
-  images,
-}: {
-  images: Array<{ presignedUrl: string | null; name: string }>;
-}) {
-  return (
-    <ul className="grid grid-cols-3 grid-rows-3 place-content-around aspect-square w-[125mm] gap-[6mm] p-[3mm] m-3 bg-white border-2">
-      {images.map((magnet, i) => (
-        <li key={i} className="bg-black relative overflow-clip">
-          <img
-            src={magnet.presignedUrl || "BROKE"}
-            alt={magnet.name}
-            className="absolute inset-0 object-cover w-full h-full"
-          />
-        </li>
-      ))}
-    </ul>
-  );
 }

--- a/app/routes/download-or-print.tsx
+++ b/app/routes/download-or-print.tsx
@@ -51,6 +51,7 @@ export default function DownloadOrPrint() {
     bgImage: background || "https://picsum.photos/id/17/3000/2000",
   }).toString();
   const pdfUrl = `/preview-plan.pdf?${params}`;
+  const pngUrl = `/preview-plan.png?${params}`;
   return (
     <>
       <h1>Print With Us</h1>
@@ -99,7 +100,12 @@ export default function DownloadOrPrint() {
           <MagnetGrid images={images} />
         </div>
       ))}
-      <a href={pdfUrl}>PDF Download</a>
+      <a href={pngUrl} download={true}>
+        PNG Download
+      </a>
+      <a href={pdfUrl} download={true}>
+        PDF Download
+      </a>
       <iframe
         src={pdfUrl}
         width="800"

--- a/app/routes/download-or-print.tsx
+++ b/app/routes/download-or-print.tsx
@@ -90,7 +90,9 @@ export default function DownloadOrPrint() {
         ))}
       </ul>
       {setupMagnetGroups(presignedMagnets).map((images, i) => (
-        <MagnetGrid key={i} images={images} />
+        <div key={i} className="border-2">
+          <MagnetGrid images={images} />
+        </div>
       ))}
       <a href={pdfUrl}>PDF Download</a>
       <iframe

--- a/app/routes/download-or-print.tsx
+++ b/app/routes/download-or-print.tsx
@@ -5,6 +5,7 @@ import { getDownloadUrl } from "./get-download-url";
 import { MagnetGrid } from "~/components/MagnetGrid";
 import { getPreviewMagnetUrl } from "./preview-magnets";
 import { setupMagnetGroups, SignedMagnet } from "~/store/Magnet";
+import { getPreviewMagnetPngUrl } from "./preview-magnets[.]png";
 
 /** The client side loader, which runs after hydrate. Data from the serverLoader (`loader()`) is also available. */
 export async function clientLoader() {
@@ -85,7 +86,11 @@ export default function DownloadOrPrint() {
       <ul>
         {setupMagnetGroups(magnets).map((imagesForGrid, i) => (
           <li key={i}>
-            <a href={getPreviewMagnetUrl(imagesForGrid)}>Link to grid {i}</a>
+            Link to:
+            <a href={getPreviewMagnetUrl(imagesForGrid)}>Preview</a>
+            <a href={getPreviewMagnetPngUrl(imagesForGrid)} download={true}>
+              Download PNG
+            </a>
           </li>
         ))}
       </ul>

--- a/app/routes/preview-magnets.tsx
+++ b/app/routes/preview-magnets.tsx
@@ -2,7 +2,7 @@ import { useLoaderData } from "@remix-run/react";
 import { LoaderFunctionArgs } from "@remix-run/node";
 import { memoizeWith } from "ramda";
 import { getSignedUrlForItem } from "~/.server/s3";
-import { Magnet, SignedMagnet } from "~/store/Magnet";
+import { Magnet, SignedMagnet, getUrlParamsForMagnets } from "~/store/Magnet";
 import { MagnetGrid } from "~/components/MagnetGrid";
 
 /**
@@ -19,10 +19,7 @@ export default function PreviewMagnets() {
 
 /** Generate a preview URL for this page with given magnet data in search parameters */
 export function getPreviewMagnetUrl(magnets: Array<Magnet>) {
-  const params = new URLSearchParams();
-  for (const m of magnets) {
-    params.append("magnets", JSON.stringify(m));
-  }
+  const params = getUrlParamsForMagnets(magnets);
   return `/preview-magnets?${params.toString()}`;
 }
 

--- a/app/routes/preview-magnets.tsx
+++ b/app/routes/preview-magnets.tsx
@@ -3,6 +3,7 @@ import { LoaderFunctionArgs } from "@remix-run/node";
 import { memoizeWith } from "ramda";
 import { getSignedUrlForItem } from "~/.server/s3";
 import { Magnet, SignedMagnet } from "~/store/Magnet";
+import { MagnetGrid } from "~/components/MagnetGrid";
 
 /**
 This page displays a 3x3 magnet grid.
@@ -13,8 +14,7 @@ Use `getPreviewMagnetUrl()` to generate a correctly formatted URL for this page.
 */
 export default function PreviewMagnets() {
   const { images } = useLoaderData<typeof loader>();
-  return <p>Images: {images.map((m) => m.name).join(",")}</p>;
-  // return <MagnetGrid images={[]} />;
+  return <MagnetGrid images={images} />;
 }
 
 /** Generate a preview URL for this page with given magnet data in search parameters */

--- a/app/routes/preview-magnets.tsx
+++ b/app/routes/preview-magnets.tsx
@@ -1,0 +1,60 @@
+import { useLoaderData } from "@remix-run/react";
+import { LoaderFunctionArgs } from "@remix-run/node";
+import { memoizeWith } from "ramda";
+import { getSignedUrlForItem } from "~/.server/s3";
+import { Magnet, SignedMagnet } from "~/store/Magnet";
+
+/**
+This page displays a 3x3 magnet grid.
+
+Each magnet's info (including upload keys) should be passed in as JSON in URL search parameters.
+
+Use `getPreviewMagnetUrl()` to generate a correctly formatted URL for this page.
+*/
+export default function PreviewMagnets() {
+  const { images } = useLoaderData<typeof loader>();
+  return <p>Images: {images.map((m) => m.name).join(",")}</p>;
+  // return <MagnetGrid images={[]} />;
+}
+
+/** Generate a preview URL for this page with given magnet data in search parameters */
+export function getPreviewMagnetUrl(magnets: Array<Magnet>) {
+  const params = new URLSearchParams();
+  for (const m of magnets) {
+    params.append("magnets", JSON.stringify(m));
+  }
+  return `/preview-magnets?${params.toString()}`;
+}
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const url = new URL(request.url);
+
+  // Use `memoizeWith` to cache calls to `getSignedUrlForItem()` so we don't pre-sign the same image multiple times
+  // (Because that makes an API call that is slow and contributes to our billing, and it'll be slower to download for the end user)
+  const memoizePresignedUrl: (uploadKey: string) => Promise<string> =
+    memoizeWith(
+      (key) => key,
+      (key) => getSignedUrlForItem(key)
+    );
+
+  const magnets: Array<Magnet> = url.searchParams
+    .getAll("magnets")
+    .map((json) => JSON.parse(json));
+
+  const magnetImages: Array<SignedMagnet> = (
+    await Promise.all(
+      magnets.map(async (m) => {
+        return (
+          m.uploadKey && {
+            ...m,
+            presignedUrl: await memoizePresignedUrl(m.uploadKey),
+          }
+        );
+      })
+    )
+  )
+    // Note: this type assertion won't be needed in Typescript 5.5
+    // https://devblogs.microsoft.com/typescript/announcing-typescript-5-5-beta/#inferred-type-predicates
+    .filter((m): m is SignedMagnet => m !== null);
+  return { images: magnetImages };
+}

--- a/app/routes/preview-magnets[.]png.tsx
+++ b/app/routes/preview-magnets[.]png.tsx
@@ -1,6 +1,12 @@
 import { LoaderFunctionArgs } from "@remix-run/node";
+import { Magnet, getUrlParamsForMagnets } from "~/store/Magnet";
 import { generatePngFromUrl } from "~/utils/playwright";
 
+/**
+Render a PNG of the `/preview-magnets` page using Playwright.
+
+Use `getPreviewMagnetPngUrl()` to generate correct URLs
+*/
 export async function loader({ request }: LoaderFunctionArgs) {
   // Get the same URL, with the query parameters, except `preview-magnets` instead of `preview-magnets.png`
   const svgUrl = new URL(request.url);
@@ -13,4 +19,10 @@ export async function loader({ request }: LoaderFunctionArgs) {
       "Content-Type": "image/png",
     },
   });
+}
+
+/** Generate a preview URL for this page with given magnet data in search parameters */
+export function getPreviewMagnetPngUrl(magnets: Array<Magnet>) {
+  const params = getUrlParamsForMagnets(magnets);
+  return `/preview-magnets.png?${params.toString()}`;
 }

--- a/app/routes/preview-magnets[.]png.tsx
+++ b/app/routes/preview-magnets[.]png.tsx
@@ -1,0 +1,16 @@
+import { LoaderFunctionArgs } from "@remix-run/node";
+import { generatePngFromUrl } from "~/utils/playwright";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  // Get the same URL, with the query parameters, except `preview-magnets` instead of `preview-magnets.png`
+  const svgUrl = new URL(request.url);
+  svgUrl.pathname = "preview-magnets";
+
+  const png = await generatePngFromUrl(svgUrl.toString());
+  return new Response(png, {
+    status: 200,
+    headers: {
+      "Content-Type": "image/png",
+    },
+  });
+}

--- a/app/routes/preview-magnets[.]png.tsx
+++ b/app/routes/preview-magnets[.]png.tsx
@@ -9,10 +9,14 @@ Use `getPreviewMagnetPngUrl()` to generate correct URLs
 */
 export async function loader({ request }: LoaderFunctionArgs) {
   // Get the same URL, with the query parameters, except `preview-magnets` instead of `preview-magnets.png`
-  const svgUrl = new URL(request.url);
-  svgUrl.pathname = "preview-magnets";
+  const previewUrl = new URL(request.url);
+  previewUrl.pathname = "preview-magnets";
 
-  const png = await generatePngFromUrl(svgUrl.toString());
+  const png = await generatePngFromUrl({
+    url: previewUrl.toString(),
+    widthInMM: 125,
+    heightInMM: 125,
+  });
   return new Response(png, {
     status: 200,
     headers: {

--- a/app/routes/preview-plan[.]pdf.tsx
+++ b/app/routes/preview-plan[.]pdf.tsx
@@ -1,5 +1,5 @@
 import { LoaderFunctionArgs } from "@remix-run/node";
-import { chromium, devices } from "playwright";
+import { generatePdfFromUrl } from "~/utils/playwright";
 
 export async function loader({ request }: LoaderFunctionArgs) {
   // Get the same URL, with the query parameters, except `preview-plan.svg` instead of `preview-plan.pdf`
@@ -13,15 +13,4 @@ export async function loader({ request }: LoaderFunctionArgs) {
       "Content-Type": "application/pdf",
     },
   });
-}
-
-async function generatePdfFromUrl(url: string) {
-  const browser = await chromium.launch();
-  const context = await browser.newContext(devices["Desktop Chrome"]);
-  const page = await context.newPage();
-  await page.goto(url);
-  const pdfBuffer = await page.pdf({ width: "30cm", height: "20cm" });
-  await context.close();
-  await browser.close();
-  return pdfBuffer;
 }

--- a/app/routes/preview-plan[.]png.tsx
+++ b/app/routes/preview-plan[.]png.tsx
@@ -1,12 +1,10 @@
 import { LoaderFunctionArgs } from "@remix-run/node";
-import { chromium, devices } from "playwright";
+import { generatePngFromUrl } from "~/utils/playwright";
 
 export async function loader({ request }: LoaderFunctionArgs) {
   // Get the same URL, with the query parameters, except `preview-plan.svg` instead of `preview-plan.png`
   const svgUrl = new URL(request.url);
   svgUrl.pathname = "preview-plan.svg";
-
-  console.log("generate png", svgUrl);
 
   const png = await generatePngFromUrl(svgUrl.toString());
   return new Response(png, {
@@ -15,27 +13,4 @@ export async function loader({ request }: LoaderFunctionArgs) {
       "Content-Type": "image/png",
     },
   });
-}
-
-async function generatePngFromUrl(url: string) {
-  const browser = await chromium.launch();
-  const context = await browser.newContext(devices["Desktop Chrome"]);
-  const page = await context.newPage();
-  // Note, calling `page.screenshot()` seems to hang for unknown reasons.
-  // This comment on GitHub suggested using raw "Chrome Devtools Protocol" (cdp)
-  // https://github.com/microsoft/playwright/issues/15773#issuecomment-1292776820
-  const cdpSession = await context.newCDPSession(page);
-  await page.goto(url);
-  // TODO: figure out how to make the SVG export at the size we want. The inkscape export of 300mm*200mm at 300dpi is 3543 × 2362
-  page.setViewportSize({ width: 1133, height: 755 });
-  const screenshotReturnValue = await cdpSession.send(
-    "Page.captureScreenshot",
-    {
-      captureBeyondViewport: true,
-    }
-  );
-  const base64Str = screenshotReturnValue.data;
-  await context.close();
-  await browser.close();
-  return Buffer.from(base64Str, "base64");
 }

--- a/app/routes/preview-plan[.]png.tsx
+++ b/app/routes/preview-plan[.]png.tsx
@@ -6,7 +6,11 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const svgUrl = new URL(request.url);
   svgUrl.pathname = "preview-plan.svg";
 
-  const png = await generatePngFromUrl(svgUrl.toString());
+  const png = await generatePngFromUrl({
+    url: svgUrl.toString(),
+    widthInMM: 300,
+    heightInMM: 200,
+  });
   return new Response(png, {
     status: 200,
     headers: {

--- a/app/store/Magnet.ts
+++ b/app/store/Magnet.ts
@@ -22,3 +22,12 @@ export function setupMagnetGroups<T extends Magnet>(magnets: Array<T>) {
   );
   return splitEvery(9)(allImages);
 }
+
+/** Get URL parameters of these magnets. Used for generating URLs to magnet previews. */
+export function getUrlParamsForMagnets(magnets: Array<Magnet>) {
+  const params = new URLSearchParams();
+  for (const m of magnets) {
+    params.append("magnets", JSON.stringify(m));
+  }
+  return params;
+}

--- a/app/store/Magnet.ts
+++ b/app/store/Magnet.ts
@@ -1,0 +1,24 @@
+import { splitEvery, repeat } from "ramda";
+
+export type Magnet = {
+  id: string;
+  name: string;
+  quantity: number;
+  uploadKey?: string;
+};
+
+export type SignedMagnet = Magnet & {
+  presignedUrl: string;
+};
+
+/**
+Given an array of MagnetImages:
+- copy each image the specified number of times in "quantity"
+- and then split into groups of 9
+*/
+export function setupMagnetGroups<T extends Magnet>(magnets: Array<T>) {
+  const allImages = magnets.flatMap((magnet) =>
+    repeat(magnet, magnet.quantity)
+  );
+  return splitEvery(9)(allImages);
+}

--- a/app/store/page.client.ts
+++ b/app/store/page.client.ts
@@ -1,11 +1,5 @@
 import { persistentAtom } from "@nanostores/persistent";
-
-export type Magnet = {
-  id: string;
-  name: string;
-  quantity: number;
-  uploadKey?: string;
-};
+import { Magnet } from "./Magnet";
 
 export type Page = {
   name: string;

--- a/app/utils/playwright.test.ts
+++ b/app/utils/playwright.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "vitest";
+import { generatePngFromUrl, getPrintViewport } from "./playwright";
+import sizeOf from "image-size";
+
+test("getPrintViewort for 125mm magnet grid", () => {
+  // At 360 DPI, Inkscape exported a 125mm square grid as 1772 by 1772px
+  expect(getPrintViewport(125, 125)).toStrictEqual({
+    x: 0,
+    y: 0,
+    height: 472,
+    width: 472,
+    scale: 1.5625,
+  });
+});
+
+test("generatePngFromUrl produces the expected size for 125x125mm", async () => {
+  const pngBuffer = await generatePngFromUrl({
+    url: "about:blank",
+    widthInMM: 125,
+    heightInMM: 125,
+  });
+  const { width, height } = sizeOf(pngBuffer);
+  // Note: these values are sometimes 1px off, with different rounding to what I expect if I calculate manually.
+  // It's close enough though, and I don't care to dive into Chrome/Playwright internals to understand the slight differences.
+  expect(width).toBe(1475);
+  expect(height).toBe(1475);
+});
+
+test("generatePngFromUrl produces the expected size for 300x200mm", async () => {
+  const pngBuffer = await generatePngFromUrl({
+    url: "about:blank",
+    widthInMM: 300,
+    heightInMM: 200,
+  });
+  const { width, height } = sizeOf(pngBuffer);
+  // Note: these values are sometimes 1px off, with different rounding to what I expect if I calculate manually.
+  // It's close enough though, and I don't care to dive into Chrome/Playwright internals to understand the slight differences.
+  expect(width).toBe(3544);
+  expect(height).toBe(2363);
+});

--- a/app/utils/playwright.ts
+++ b/app/utils/playwright.ts
@@ -1,0 +1,35 @@
+import { chromium, devices } from "playwright";
+
+export async function generatePngFromUrl(url: string) {
+  const browser = await chromium.launch();
+  const context = await browser.newContext(devices["Desktop Chrome"]);
+  const page = await context.newPage();
+  // Note, calling `page.screenshot()` seems to hang for unknown reasons.
+  // This comment on GitHub suggested using raw "Chrome Devtools Protocol" (cdp)
+  // https://github.com/microsoft/playwright/issues/15773#issuecomment-1292776820
+  const cdpSession = await context.newCDPSession(page);
+  await page.goto(url);
+  // TODO: figure out how to make the SVG export at the size we want. The inkscape export of 300mm*200mm at 300dpi is 3543 × 2362
+  page.setViewportSize({ width: 1133, height: 755 });
+  const screenshotReturnValue = await cdpSession.send(
+    "Page.captureScreenshot",
+    {
+      captureBeyondViewport: true,
+    }
+  );
+  const base64Str = screenshotReturnValue.data;
+  await context.close();
+  await browser.close();
+  return Buffer.from(base64Str, "base64");
+}
+
+export async function generatePdfFromUrl(url: string) {
+  const browser = await chromium.launch();
+  const context = await browser.newContext(devices["Desktop Chrome"]);
+  const page = await context.newPage();
+  await page.goto(url);
+  const pdfBuffer = await page.pdf({ width: "30cm", height: "20cm" });
+  await context.close();
+  await browser.close();
+  return pdfBuffer;
+}

--- a/app/utils/playwright.ts
+++ b/app/utils/playwright.ts
@@ -1,6 +1,14 @@
 import { chromium, devices } from "playwright";
 
-export async function generatePngFromUrl(url: string) {
+export async function generatePngFromUrl({
+  url,
+  widthInMM,
+  heightInMM,
+}: {
+  url: string;
+  widthInMM: number;
+  heightInMM: number;
+}) {
   const browser = await chromium.launch();
   const context = await browser.newContext(devices["Desktop Chrome"]);
   const page = await context.newPage();
@@ -9,11 +17,14 @@ export async function generatePngFromUrl(url: string) {
   // https://github.com/microsoft/playwright/issues/15773#issuecomment-1292776820
   const cdpSession = await context.newCDPSession(page);
   await page.goto(url);
-  // TODO: figure out how to make the SVG export at the size we want. The inkscape export of 300mm*200mm at 300dpi is 3543 × 2362
-  page.setViewportSize({ width: 1133, height: 755 });
+
+  const viewport = getPrintViewport(widthInMM, heightInMM);
+  page.setViewportSize({ width: viewport.width, height: viewport.height });
+
   const screenshotReturnValue = await cdpSession.send(
     "Page.captureScreenshot",
     {
+      clip: viewport,
       captureBeyondViewport: true,
     }
   );
@@ -21,6 +32,28 @@ export async function generatePngFromUrl(url: string) {
   await context.close();
   await browser.close();
   return Buffer.from(base64Str, "base64");
+}
+
+/**
+Get the Viewport with with and height set correctly for the web DPI (96), and `scale` set correctly that we get our desired print DPI (360).
+*/
+export function getPrintViewport(
+  widthInMM: number,
+  heighInMM: number
+): { x: number; y: number; width: number; height: number; scale: number } {
+  const CSS_DPI = 96;
+  const CSS_DOTS_PER_MM = CSS_DPI / 25.4;
+  const PRINT_DPI = 300;
+  // NOTE: All my calculations were off by 2, which I think is to do with High DPI scaling on my macbook, but I don't know how to verify.
+  // When we test on different laptops / CI / hosted servers, I'll be interested to see if this value needs to change.
+  const HIGH_DPI_SCALING = 2;
+  return {
+    x: 0,
+    y: 0,
+    width: Math.round(widthInMM * CSS_DOTS_PER_MM),
+    height: Math.round(heighInMM * CSS_DOTS_PER_MM),
+    scale: PRINT_DPI / CSS_DPI / HIGH_DPI_SCALING,
+  };
 }
 
 export async function generatePdfFromUrl(url: string) {

--- a/package.json
+++ b/package.json
@@ -22,10 +22,12 @@
     "@remix-run/node": "^2.8.1",
     "@remix-run/react": "^2.8.1",
     "@remix-run/serve": "^2.8.1",
+    "@types/ramda": "^0.30.0",
     "@types/uuid": "^9.0.8",
     "isbot": "^4.1.0",
     "playwright": "^1.43.1",
     "prettier": "^3.2.5",
+    "ramda": "^0.30.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "uuid": "^9.0.1"

--- a/package.json
+++ b/package.json
@@ -45,11 +45,13 @@
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "image-size": "^1.1.1",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.3",
     "typescript": "^5.1.6",
     "vite": "^5.1.0",
-    "vite-tsconfig-paths": "^4.2.1"
+    "vite-tsconfig-paths": "^4.2.1",
+    "vitest": "^1.6.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ dependencies:
   '@remix-run/serve':
     specifier: ^2.8.1
     version: 2.8.1(typescript@5.1.6)
+  '@types/ramda':
+    specifier: ^0.30.0
+    version: 0.30.0
   '@types/uuid':
     specifier: ^9.0.8
     version: 9.0.8
@@ -44,6 +47,9 @@ dependencies:
   prettier:
     specifier: ^3.2.5
     version: 3.2.5
+  ramda:
+    specifier: ^0.30.1
+    version: 0.30.1
   react:
     specifier: ^18.2.0
     version: 18.2.0
@@ -2691,6 +2697,12 @@ packages:
   /@types/prop-types@15.7.12:
     resolution: {integrity: sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==}
     dev: true
+
+  /@types/ramda@0.30.0:
+    resolution: {integrity: sha512-DQtfqUbSB18iM9NHbQ++kVUDuBWHMr6T2FpW1XTiksYRGjq4WnNPZLt712OEHEBJs7aMyJ68Mf2kGMOP1srVVw==}
+    dependencies:
+      types-ramda: 0.30.0
+    dev: false
 
   /@types/react-dom@18.2.7:
     resolution: {integrity: sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==}
@@ -6465,6 +6477,10 @@ packages:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: true
 
+  /ramda@0.30.1:
+    resolution: {integrity: sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==}
+    dev: false
+
   /range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -7226,6 +7242,10 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
+  /ts-toolbelt@9.6.0:
+    resolution: {integrity: sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==}
+    dev: false
+
   /tsconfck@2.1.2(typescript@5.1.6):
     resolution: {integrity: sha512-ghqN1b0puy3MhhviwO2kGF8SeMDNhEbnKxjK7h6+fvY9JAxqvXi8y5NAHSQv687OVboS2uZIByzGd45/YxrRHg==}
     engines: {node: ^14.13.1 || ^16 || >=18}
@@ -7327,6 +7347,12 @@ packages:
       is-typed-array: 1.1.13
       possible-typed-array-names: 1.0.0
     dev: true
+
+  /types-ramda@0.30.0:
+    resolution: {integrity: sha512-oVPw/KHB5M0Du0txTEKKM8xZOG9cZBRdCVXvwHYuNJUVkAiJ9oWyqkA+9Bj2gjMsHgkkhsYevobQBWs8I2/Xvw==}
+    dependencies:
+      ts-toolbelt: 9.6.0
+    dev: false
 
   /typescript@5.1.6:
     resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,9 @@ devDependencies:
   eslint-plugin-react-hooks:
     specifier: ^4.6.0
     version: 4.6.0(eslint@8.38.0)
+  image-size:
+    specifier: ^1.1.1
+    version: 1.1.1
   postcss:
     specifier: ^8.4.38
     version: 8.4.38
@@ -112,6 +115,9 @@ devDependencies:
   vite-tsconfig-paths:
     specifier: ^4.2.1
     version: 4.2.1(typescript@5.1.6)(vite@5.1.0)
+  vitest:
+    specifier: ^1.6.0
+    version: 1.6.0
 
 packages:
 
@@ -1681,6 +1687,13 @@ packages:
       wrap-ansi-cjs: /wrap-ansi@7.0.0
     dev: true
 
+  /@jest/schemas@29.6.3:
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@sinclair/typebox': 0.27.8
+    dev: true
+
   /@jridgewell/gen-mapping@0.3.5:
     resolution: {integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==}
     engines: {node: '>=6.0.0'}
@@ -2179,6 +2192,10 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /@sinclair/typebox@0.27.8:
+    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+    dev: true
 
   /@smithy/abort-controller@2.2.0:
     resolution: {integrity: sha512-wRlta7GuLWpTqtFfGo+nZyOO1vEvewdNR1R4rTxpC8XU6vG/NDyrFBhwLZsqg1NUoR1noVaXJPC/7ZK47QCySw==}
@@ -2920,6 +2937,45 @@ packages:
     resolution: {integrity: sha512-8FGD6AejeC/nXcblgNCM5rnZb9KXa4WNkR03HCWtdJBpANjTgjHEglNLFnhuvdQ78tC6afaxBPI+g7F2NX3tgg==}
     dev: true
 
+  /@vitest/expect@1.6.0:
+    resolution: {integrity: sha512-ixEvFVQjycy/oNgHjqsL6AZCDduC+tflRluaHIzKIsdbzkLn2U/iBnVeJwB6HsIjQBdfMR8Z0tRxKUsvFJEeWQ==}
+    dependencies:
+      '@vitest/spy': 1.6.0
+      '@vitest/utils': 1.6.0
+      chai: 4.4.1
+    dev: true
+
+  /@vitest/runner@1.6.0:
+    resolution: {integrity: sha512-P4xgwPjwesuBiHisAVz/LSSZtDjOTPYZVmNAnpHHSR6ONrf8eCJOFRvUwdHn30F5M1fxhqtl7QZQUk2dprIXAg==}
+    dependencies:
+      '@vitest/utils': 1.6.0
+      p-limit: 5.0.0
+      pathe: 1.1.2
+    dev: true
+
+  /@vitest/snapshot@1.6.0:
+    resolution: {integrity: sha512-+Hx43f8Chus+DCmygqqfetcAZrDJwvTj0ymqjQq4CvmpKFSTVteEOBzCusu1x2tt4OJcvBflyHUE0DZSLgEMtQ==}
+    dependencies:
+      magic-string: 0.30.10
+      pathe: 1.1.2
+      pretty-format: 29.7.0
+    dev: true
+
+  /@vitest/spy@1.6.0:
+    resolution: {integrity: sha512-leUTap6B/cqi/bQkXUu6bQV5TZPx7pmMBKBQiI0rJA8c3pB56ZsaTbREnF7CJfmvAS4V2cXIBAh/3rVwrrCYgw==}
+    dependencies:
+      tinyspy: 2.2.1
+    dev: true
+
+  /@vitest/utils@1.6.0:
+    resolution: {integrity: sha512-21cPiuGMoMZwiOHa2i4LXkMkMkCGzA+MVFV70jRwHo95dL4x/ts5GZhML1QWuy7yfp3WzK3lRvZi3JnXTYqrBw==}
+    dependencies:
+      diff-sequences: 29.6.3
+      estree-walker: 3.0.3
+      loupe: 2.3.7
+      pretty-format: 29.7.0
+    dev: true
+
   /@web3-storage/multipart-parser@1.0.0:
     resolution: {integrity: sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==}
 
@@ -2947,6 +3003,11 @@ packages:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       acorn: 8.11.3
+    dev: true
+
+  /acorn-walk@8.3.2:
+    resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
+    engines: {node: '>=0.4.0'}
     dev: true
 
   /acorn@8.11.3:
@@ -2994,6 +3055,11 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
+    dev: true
+
+  /ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
     dev: true
 
   /ansi-styles@6.2.1:
@@ -3108,6 +3174,10 @@ packages:
       get-intrinsic: 1.2.4
       is-array-buffer: 3.0.4
       is-shared-array-buffer: 1.0.3
+    dev: true
+
+  /assertion-error@1.1.0:
+    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
     dev: true
 
   /ast-types-flow@0.0.7:
@@ -3316,6 +3386,19 @@ packages:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
     dev: true
 
+  /chai@4.4.1:
+    resolution: {integrity: sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==}
+    engines: {node: '>=4'}
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.3
+      deep-eql: 4.1.4
+      get-func-name: 2.0.2
+      loupe: 2.3.7
+      pathval: 1.1.1
+      type-detect: 4.0.8
+    dev: true
+
   /chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -3347,6 +3430,12 @@ packages:
 
   /character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+    dev: true
+
+  /check-error@1.0.3:
+    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+    dependencies:
+      get-func-name: 2.0.2
     dev: true
 
   /chokidar@3.6.0:
@@ -3575,6 +3664,13 @@ packages:
       character-entities: 2.0.2
     dev: true
 
+  /deep-eql@4.1.4:
+    resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
+    engines: {node: '>=6'}
+    dependencies:
+      type-detect: 4.0.8
+    dev: true
+
   /deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
     dev: true
@@ -3626,6 +3722,11 @@ packages:
 
   /didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+    dev: true
+
+  /diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dev: true
 
   /diff@5.2.0:
@@ -4254,6 +4355,21 @@ packages:
       strip-final-newline: 2.0.0
     dev: true
 
+  /execa@8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.3.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
+    dev: true
+
   /exit-hook@2.2.1:
     resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
     engines: {node: '>=6'}
@@ -4495,6 +4611,10 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
+  /get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+    dev: true
+
   /get-intrinsic@1.2.4:
     resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
     engines: {node: '>= 0.4'}
@@ -4512,6 +4632,11 @@ packages:
   /get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
+    dev: true
+
+  /get-stream@8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
     dev: true
 
   /get-symbol-description@1.0.2:
@@ -4721,6 +4846,11 @@ packages:
     engines: {node: '>=10.17.0'}
     dev: true
 
+  /human-signals@5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
+    dev: true
+
   /iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -4743,6 +4873,14 @@ packages:
   /ignore@5.3.1:
     resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
     engines: {node: '>= 4'}
+    dev: true
+
+  /image-size@1.1.1:
+    resolution: {integrity: sha512-541xKlUw6jr/6gGuk92F+mYM5zaFAc5ahphvkqvNe2bQ6gVBkd6bfrmVJ2t4KDAfikAYZyIqTnktX3i6/aQDrQ==}
+    engines: {node: '>=16.x'}
+    hasBin: true
+    dependencies:
+      queue: 6.0.2
     dev: true
 
   /import-fresh@3.3.0:
@@ -4988,6 +5126,11 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /is-stream@3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: true
+
   /is-string@1.0.7:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
     engines: {node: '>= 0.4'}
@@ -5083,6 +5226,10 @@ packages:
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  /js-tokens@9.0.0:
+    resolution: {integrity: sha512-WriZw1luRMlmV3LGJaR6QOJjWwgLUTf89OwT2lUOyjX2dJGBwgmIkbcz+7WFZjrZM635JOIR517++e/67CP9dQ==}
+    dev: true
 
   /js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -5252,6 +5399,12 @@ packages:
     dependencies:
       js-tokens: 4.0.0
 
+  /loupe@2.3.7:
+    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
+    dependencies:
+      get-func-name: 2.0.2
+    dev: true
+
   /lru-cache@10.2.0:
     resolution: {integrity: sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==}
     engines: {node: 14 || >=16.14}
@@ -5273,6 +5426,12 @@ packages:
   /lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
+    dev: true
+
+  /magic-string@0.30.10:
+    resolution: {integrity: sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
   /markdown-extensions@1.1.1:
@@ -5734,6 +5893,11 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /mimic-fn@4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
+    dev: true
+
   /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
@@ -5940,6 +6104,13 @@ packages:
       path-key: 3.1.1
     dev: true
 
+  /npm-run-path@5.3.0:
+    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      path-key: 4.0.0
+    dev: true
+
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -6043,6 +6214,13 @@ packages:
       mimic-fn: 2.1.0
     dev: true
 
+  /onetime@6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      mimic-fn: 4.0.0
+    dev: true
+
   /optionator@0.9.3:
     resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
     engines: {node: '>= 0.8.0'}
@@ -6079,6 +6257,13 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yocto-queue: 0.1.0
+    dev: true
+
+  /p-limit@5.0.0:
+    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      yocto-queue: 1.0.0
     dev: true
 
   /p-locate@5.0.0:
@@ -6143,6 +6328,11 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
+    dev: true
+
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
     dev: true
@@ -6165,6 +6355,10 @@ packages:
 
   /pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+    dev: true
+
+  /pathval@1.1.1:
+    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
     dev: true
 
   /peek-stream@1.1.3:
@@ -6388,6 +6582,15 @@ packages:
     hasBin: true
     dev: false
 
+  /pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+    dev: true
+
   /pretty-ms@7.0.1:
     resolution: {integrity: sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==}
     engines: {node: '>=10'}
@@ -6477,6 +6680,12 @@ packages:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: true
 
+  /queue@6.0.2:
+    resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
+    dependencies:
+      inherits: 2.0.4
+    dev: true
+
   /ramda@0.30.1:
     resolution: {integrity: sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==}
     dev: false
@@ -6506,6 +6715,10 @@ packages:
 
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+    dev: true
+
+  /react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
     dev: true
 
   /react-refresh@0.14.0:
@@ -6875,6 +7088,10 @@ packages:
       get-intrinsic: 1.2.4
       object-inspect: 1.13.1
 
+  /siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+    dev: true
+
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
     dev: true
@@ -6941,9 +7158,17 @@ packages:
       minipass: 7.0.4
     dev: true
 
+  /stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+    dev: true
+
   /statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
+
+  /std-env@3.7.0:
+    resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
+    dev: true
 
   /stream-shift@1.0.3:
     resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
@@ -7062,9 +7287,20 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /strip-final-newline@3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
+    dev: true
+
   /strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+    dev: true
+
+  /strip-literal@2.1.0:
+    resolution: {integrity: sha512-Op+UycaUt/8FbN/Z2TWPBLge3jWrP3xj10f3fnYxf052bKuS3EKs1ZQcVGjnEMdsNVAM+plXRdmjrZ/KgG3Skw==}
+    dependencies:
+      js-tokens: 9.0.0
     dev: true
 
   /strnum@1.0.5:
@@ -7202,6 +7438,20 @@ packages:
       xtend: 4.0.2
     dev: true
 
+  /tinybench@2.8.0:
+    resolution: {integrity: sha512-1/eK7zUnIklz4JUUlL+658n58XO2hHLQfSk1Zf2LKieUjxidN16eKFEoDEfjHc3ohofSSqK3X5yO6VGb6iW8Lw==}
+    dev: true
+
+  /tinypool@0.8.4:
+    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
+  /tinyspy@2.2.1:
+    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
   /to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
@@ -7290,6 +7540,11 @@ packages:
     engines: {node: '>= 0.8.0'}
     dependencies:
       prelude-ls: 1.2.1
+    dev: true
+
+  /type-detect@4.0.8:
+    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
+    engines: {node: '>=4'}
     dev: true
 
   /type-fest@0.20.2:
@@ -7566,6 +7821,27 @@ packages:
       - terser
     dev: true
 
+  /vite-node@1.6.0:
+    resolution: {integrity: sha512-de6HJgzC+TFzOu0NTC4RAIsyf/DY/ibWDYQUcuEA84EMHhcefTUGkjFHKKEJhQN4A+6I0u++kr3l36ZF2d7XRw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4
+      pathe: 1.1.2
+      picocolors: 1.0.0
+      vite: 5.1.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
   /vite-tsconfig-paths@4.2.1(typescript@5.1.6)(vite@5.1.0):
     resolution: {integrity: sha512-GNUI6ZgPqT3oervkvzU+qtys83+75N/OuDaQl7HmOqFTb0pjZsuARrRipsyJhJ3enqV8beI1xhGbToR4o78nSQ==}
     peerDependencies:
@@ -7616,6 +7892,61 @@ packages:
       rollup: 4.14.1
     optionalDependencies:
       fsevents: 2.3.3
+    dev: true
+
+  /vitest@1.6.0:
+    resolution: {integrity: sha512-H5r/dN06swuFnzNFhq/dnz37bPXnq8xB2xB5JOVk8K09rUtoeNN+LHWkoQ0A/i3hvbUKKcCei9KpbxqHMLhLLA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 1.6.0
+      '@vitest/ui': 1.6.0
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@vitest/expect': 1.6.0
+      '@vitest/runner': 1.6.0
+      '@vitest/snapshot': 1.6.0
+      '@vitest/spy': 1.6.0
+      '@vitest/utils': 1.6.0
+      acorn-walk: 8.3.2
+      chai: 4.4.1
+      debug: 4.3.4
+      execa: 8.0.1
+      local-pkg: 0.5.0
+      magic-string: 0.30.10
+      pathe: 1.1.2
+      picocolors: 1.0.0
+      std-env: 3.7.0
+      strip-literal: 2.1.0
+      tinybench: 2.8.0
+      tinypool: 0.8.4
+      vite: 5.1.0
+      vite-node: 1.6.0
+      why-is-node-running: 2.2.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
     dev: true
 
   /wcwidth@1.0.1:
@@ -7699,6 +8030,15 @@ packages:
       isexe: 2.0.0
     dev: true
 
+  /why-is-node-running@2.2.2:
+    resolution: {integrity: sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+    dev: true
+
   /wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -7756,6 +8096,11 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+    dev: true
+
+  /yocto-queue@1.0.0:
+    resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
+    engines: {node: '>=12.20'}
     dev: true
 
   /zwitch@2.0.4:


### PR DESCRIPTION
## Aim

Take the magnets you've uploaded and produce a print artefact (PNG or PDF) that we can take to a printer to print grids of magnets.

## Notes

- I'm not going to use Inkscape SVGs after all... HTML and CSS will be easier to work with I think.

## Todo

- [x] Get a react component to render the right number of images in the right number of grids
- [x] Figure out how to export that react component as a PNG
- [x] Link the correct PNGs on the page, and make available for download
- [x] Ensure resolution of PNGs is correct for printing

## Screenshot of result
