### PR TITLE
Fix a bug where magnet list was disappearing

### DIFF
--- a/app/routes/setup-page.tsx
+++ b/app/routes/setup-page.tsx
@@ -10,11 +10,12 @@ import { getStringFromFormData } from "~/utils/formUtils";
 
 export async function clientAction({ request }: ClientActionFunctionArgs) {
   const body = await request.formData();
+  const oldPageData = page.get();
   const pageData = {
     name: getStringFromFormData(body, "name") ?? "",
     background: getStringFromFormData(body, "background") ?? null,
     weekStart: getStringFromFormData(body, "weekStart") ?? "Sunday",
-    magnets: [],
+    magnets: oldPageData.magnets,
   };
   page.set(pageData);
   return redirect("/requirements");


### PR DESCRIPTION
This fixes a bug where after submitting on the "setup" page the list of magnets you had disappeared.

Notion card: https://www.notion.so/Fix-bug-where-requirements-page-resets-magnets-c678576b35594fb3821136cad3e8db3b?pvs=4

## Steps to reproduce

- Go through setup flow to requirements page
- Add 2 or 3 magnet names
- Check local storage, they’re all there
- Close the tab,
- Re-open the same page `/requirements`, they’re still there
- Click “Back”, they’re still there
- Click “Submit”, they’re gone