### PR TITLE
Usability: start upload as soon as a file is selected

### DIFF
--- a/app/components/ImageUploadField.tsx
+++ b/app/components/ImageUploadField.tsx
@@ -108,6 +108,7 @@ export function ImageUploadField({
               ref={fileInputRef}
               accept="image/*"
               className="hidden"
+              onChange={handleUpload}
             />
           </div>
           <button


### PR DESCRIPTION
Don't wait for the "upload" button, that kept throwing me off.

I've left the upload button there for now, which we might remove when we come back to styling these components.